### PR TITLE
Fixed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ docker run \
     --name noVNC \
     --detach \
     --publish 443:6080 \
-    --cert server.pem \
-    --ssl-only \
     gotget/novnc \
+        --cert server.pem \
+        --ssl-only \
         --vnc HOST:PORT
 ```
 


### PR DESCRIPTION
`--cert` and `--ssl-only` are parameters of novnc's [launch.sh](https://github.com/novnc/noVNC/blob/master/utils/launch.sh) script, not of `docker run`.